### PR TITLE
Linked 'Contact Us' section to the header

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,7 +188,7 @@
     </section>
 
     <!-- Contact Us section -->
-    <section class="contact-section">
+    <section class="contact-section" id="contacts">
       <h2 class="section-heading">Contact Us</h2>
       <div class="container">
         <div class="row">


### PR DESCRIPTION
Fixed the bug. Contact Us section of the website is now linked with the corresponding text in the header.